### PR TITLE
Suppress byte-compile warning

### DIFF
--- a/free-keys.el
+++ b/free-keys.el
@@ -127,7 +127,7 @@ BUFFER and update the display."
   (interactive "bShow free bindings for buffer: ")
   (free-keys nil (get-buffer-create buffer)))
 
-(defun free-keys-revert-buffer (_ _)
+(defun free-keys-revert-buffer (_ignore-auto _noconfirm)
   "Revert the *Free keys* buffer.
 
 This simply calls `free-keys'."


### PR DESCRIPTION
This patch fixes following byte-compile warning.

```
free-keys.el:130:35:Warning: repeated variable _ in lambda-list 
```